### PR TITLE
Add missing R packages (zip and osfr) to install.R

### DIFF
--- a/install.R
+++ b/install.R
@@ -13,4 +13,6 @@ install.packages("xml2")
 install.packages("rvest")
 install.packages("tidyr")
 install.packages("ggplot2")
+install.packages("zip")
+install.packages("osfr")
 remotes::install_github("tidyverse/googledrive", ref = "v1.0.0") # more convenience for upload/update in newer version


### PR DESCRIPTION
This pull request adds the two R packages `zip` and `osfr` to `install.R`, which are used in the reproduction report ([here](https://github.com/reproducible-agile/reviews-2021/blob/24de0272ec9bebba8a0dec7f259ce298482f3f32/report-template/reproreview-template.Rmd#L82) and [here](https://github.com/reproducible-agile/reviews-2021/blob/24de0272ec9bebba8a0dec7f259ce298482f3f32/report-template/reproreview-template.Rmd#L90)) while zipping and uploading data to osf.io.

Adding these lines to `install.R` should automatically install the packages and avoid a crash while executing the respective code block.

